### PR TITLE
Modify figure captions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+dest/

--- a/src/scss/_caption.scss
+++ b/src/scss/_caption.scss
@@ -64,3 +64,14 @@ caption,
     content: "リスト " counter(list) " :";
   }
 }
+
+
+/* nocaption */
+
+.nocaption {
+  counter-increment: none;
+
+  &:before {
+    content: "";
+  }
+}

--- a/src/scss/_caption.scss
+++ b/src/scss/_caption.scss
@@ -34,3 +34,13 @@ figcaption.code,
     margin-right: 0.3em;
   }
 }
+
+figcaption.list
+.caption.list {
+  counter-increment: list;
+
+  &:before {
+    content: "リスト " counter(list) " :";
+    margin-right: 0.3em;
+  }
+}

--- a/src/scss/_caption.scss
+++ b/src/scss/_caption.scss
@@ -1,12 +1,7 @@
-caption,
 figcaption,
-.caption {
+.figcaption {
   line-height: 3;
   text-align: center;
-}
-
-figcaption.fig,
-.caption.fig {
   counter-increment: fig;
 
   &:before {
@@ -15,8 +10,10 @@ figcaption.fig,
   }
 }
 
-caption.table,
-.caption.table {
+caption,
+.caption {
+  line-height: 3;
+  text-align: center;
   counter-increment: table;
 
   &:before {
@@ -25,8 +22,24 @@ caption.table,
   }
 }
 
-figcaption.code,
-.caption.code {
+.fig {
+  counter-increment: fig;
+
+  &:before {
+    content: "図 " counter(fig) " :";
+  }
+}
+
+.table {
+  counter-increment: table;
+
+  &:before {
+    content: "表 " counter(table) " :";
+    margin-right: 0.3em;
+  }
+}
+
+.code {
   counter-increment: code;
 
   &:before {
@@ -35,8 +48,7 @@ figcaption.code,
   }
 }
 
-figcaption.list
-.caption.list {
+.list {
   counter-increment: list;
 
   &:before {

--- a/src/scss/_caption.scss
+++ b/src/scss/_caption.scss
@@ -1,24 +1,35 @@
 figcaption,
-.figcaption {
+.figcaption,
+caption,
+.caption,
+.fig,
+.table,
+.code,
+.list {
   line-height: 3;
   text-align: center;
+
+  &:before {
+    content: "";
+    margin-right: 0.3em;
+  }
+}
+
+figcaption,
+.figcaption {
   counter-increment: fig;
 
   &:before {
     content: "図 " counter(fig) " :";
-    margin-right: 0.3em;
   }
 }
 
 caption,
 .caption {
-  line-height: 3;
-  text-align: center;
   counter-increment: table;
 
   &:before {
     content: "表 " counter(table) " :";
-    margin-right: 0.3em;
   }
 }
 
@@ -35,7 +46,6 @@ caption,
 
   &:before {
     content: "表 " counter(table) " :";
-    margin-right: 0.3em;
   }
 }
 
@@ -44,7 +54,6 @@ caption,
 
   &:before {
     content: "ソースコード " counter(code) " :";
-    margin-right: 0.3em;
   }
 }
 
@@ -53,6 +62,5 @@ caption,
 
   &:before {
     content: "リスト " counter(list) " :";
-    margin-right: 0.3em;
   }
 }

--- a/src/scss/_counter.scss
+++ b/src/scss/_counter.scss
@@ -1,5 +1,5 @@
 body {
-  counter-reset: h2 h3 h4 h5 code table fig page;
+  counter-reset: h2 h3 h4 h5 code table fig list page;
 }
 
 // TODO: contentの部分がうまく書けたら@eachで書ける


### PR DESCRIPTION
ref: https://github.com/yamasy1549/ZinkeN/issues/9
- Add `.list` caption
- Unite caption's common codes
- Add `dest/` to `.gitignore`

Default:
`figcaption` `.figcaption` -> `図`
`caption` `.caption` -> `表`
Nocaption:
`.nocaption`
