### PR TITLE
authorsがひとりでも複数人でも同じように出力

### DIFF
--- a/src/jade/_cover.jade
+++ b/src/jade/_cover.jade
@@ -1,14 +1,17 @@
 mixin cover(title, authors, date)
+  // とりあえずpopとjoinがあればArrayとしてる
+  - function isArray(o){ return o != null && typeof o === "object" && 'pop' in o && 'join' in o; }
+
   .page.cover
     section
       if title
         h1.title= title
       p
-        if authors.length < 2
-          span.author= authors
-        else
-          .authors
+        .authors
+          if isArray(authors)
             each author in authors
               span.author= author
+          else
+              span.author= authors
         if date
           span.date: time= date

--- a/src/jade/_variables.jade
+++ b/src/jade/_variables.jade
@@ -1,3 +1,0 @@
-- var title = "ZinkeNのつかいかた"
-- var authors = ["E14xx やましー", "E14xx ほげしー"]
-- var date = "2016年5月8日"

--- a/src/jade/index.jade
+++ b/src/jade/index.jade
@@ -1,5 +1,4 @@
 doctype html
-include ./_variables
 include ./_head
 include ./_script
 include ./_cover
@@ -10,20 +9,20 @@ html(lang="ja")
     link(href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet")
 
   body
-    +cover(title, authors, date)
+    +cover("ZinkeNのつかいかた", "E14xx やましー", "2016年5月16日")
 
     .pages
       section
         h2 表紙
         p
-          | 表紙に載せる情報
-          ul
-            li: code title
-            li: code authors
-            li: code date
-          | は Jade の変数として管理しています。
-          code src/jade/_variables.jade
-          | を編集してください。
+          | jadeファイル内
+          code body
+          | タグの次に下のように書きます。
+        figure
+          figcaption.code 表紙の書きかた
+          pre
+            :code
+              +cover("ZinkeNのつかいかた", "E14xx やましー", "2016年5月16日")
 
       section
         h2 見出しと本文


### PR DESCRIPTION
- 見た目のズレをなくした
- authors は配列でも文字列でもいけるようにした
- `src/jade/_variables.jade` をなくしてファイルごとに下のように書くようにした

```
    +cover("ZinkeNのつかいかた", "E14xx やましー", "2016年5月16日")
```
